### PR TITLE
Fix Wordpress problem of not working with custom post types

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ if ( post_password_required() )
 <a id="nodebb-comments"></a>
 <script type="text/javascript">
 var nodeBBURL = '//your.nodebb.com',
-	wordpressURL = '<?php get_site_url(); ?>',
+	wordpressURL = '<?php echo get_site_url(); ?>',
 	articleID = '<?php echo the_ID(); ?>',
 	blogger = 'name', //OPTIONAL. Assign an blogger name to disdinguish different blogger. Omit it to fallback to 'default'
 	articleType = '<?php echo get_post_type() ?>',

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ if ( post_password_required() )
 var nodeBBURL = '//your.nodebb.com',
 	wordpressURL = '<?php get_site_url(); ?>',
 	articleID = '<?php echo the_ID(); ?>',
-    blogger = 'name'; //OPTIONAL. Assign an blogger name to disdinguish different blogger. Omit it to fallback to 'default'
-	categoryID = 1; // OPTIONAL. Forces a Category ID in NodeBB.
-					 //  Omit it to fallback to specified IDs in the admin panel.
+	blogger = 'name', //OPTIONAL. Assign an blogger name to disdinguish different blogger. Omit it to fallback to 'default'
+	articleType = '<?php echo get_post_type() ?>',
+	categoryID = -1; // If -1, will use category in NodeBB ACP.  Put in a category number to force that category.
 
 (function() {
 var nbb = document.createElement('script'); nbb.type = 'text/javascript'; nbb.async = true;

--- a/public/lib/wordpress.js
+++ b/public/lib/wordpress.js
@@ -154,7 +154,7 @@
 			} else {
 				if (data.isAdmin) {
 					var adminXHR = newXHR();
-					adminXHR.open('GET', wordpressURL + '?json=get_post&post_id=' + articleID);
+					adminXHR.open('GET', wordpressURL + '?json=get_post&post_type='+articleType+'&post_id=' + articleID);
 					adminXHR.onload = function() {
 						if (adminXHR.status >= 200 && adminXHR.status < 400) {
 							var articleData = JSON.parse(adminXHR.responseText.toString()).post,


### PR DESCRIPTION
This fixes the plugin so it works with any post type in Wordpress.  The main approach is to include a Javascript variable containing the post type so the JSON API call can include the post_type argument.  That allows it to properly retrieve the contents of any post type, not just the default.

Also corrected the comment on categoryID in the Wordpress install.  It appears to be mandatory, and should be set to -1 to allow the NodeBB ACP category to be used.  

Minor fix on the wordpressURL variable not echoing out the actual site URL.  